### PR TITLE
Fix popup behavior on map zoom or pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,14 +162,16 @@
         
         const minZoom = 0.5;
         const maxZoom = 5;
-        
+
+        function hideInfoPopups() {
+            document.getElementById('udvaris-info').style.display = 'none';
+        }
+
         function updateTransform() {
             mapContainer.style.transform = `translate(${translateX}px, ${translateY}px) scale(${currentZoom})`;
+            hideInfoPopups();
         }
-        
-        function updateDotTransform() {
-            // This function is now redundant since updateTransform handles both
-        }
+
         
         function zoomIn() {
             if (currentZoom < maxZoom) {


### PR DESCRIPTION
## Summary
- ensure info popups close whenever the map is transformed
- remove unused `updateDotTransform` function
- add newline at EOF for consistency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df4be74d08332949faf939b7fac23