### PR TITLE
Fix zoom-out button label

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
         
         <div class="controls">
             <button class="zoom-btn" onclick="zoomIn()">+</button>
-            <button class="zoom-btn" onclick="zoomOut()">−</button>
+            <button class="zoom-btn" onclick="zoomOut()">-</button>
             <button class="reset-btn" onclick="resetZoom()">RESET</button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- update zoom-out button label to use a plain hyphen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dfe5dce688332a5b2ffe51610dfe6