### PR TITLE
Add Jest test for resetZoom

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('resetZoom', () => {
+  test('resets zoom and translation values', () => {
+    const html = fs.readFileSync(path.resolve(__dirname, 'index.html'), 'utf8');
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+    const { window } = dom;
+
+    // modify state so we can test reset
+    window.currentZoom = 2;
+    window.translateX = 50;
+    window.translateY = 25;
+
+    window.resetZoom();
+
+    expect(window.currentZoom).toBe(1);
+    expect(window.translateX).toBe(0);
+    expect(window.translateY).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nexus-galactic-map",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^24.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}


### PR DESCRIPTION
## Summary
- add Node/Jest test suite
- verify that `resetZoom()` resets zoom and translation values

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dfe5a750883329c31454f913df1d6